### PR TITLE
解决打包出现多个Chunk导致的使用出错问题和新增单个组件的标题宽度设置

### DIFF
--- a/packages/WidgetConfig.vue
+++ b/packages/WidgetConfig.vue
@@ -35,6 +35,16 @@
                       clearable
                       placeholder="标题"></el-input>
           </el-form-item>
+          <el-form-item label="标题宽度"
+                        v-if="!['group','dynamic','title'].includes(data.type)"
+          >
+            <el-input-number v-model="data.labelWidth"
+                :min="80"
+                :step="10"
+                controls-position="right"
+                placeholder="标签宽度"
+                style="width: 100%"></el-input-number>
+          </el-form-item>
           <el-form-item label="宽度"
                         v-if="data.subfield">
             <el-input-number style="width:100%;"

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,3 +1,4 @@
+const webpack = require('webpack')
 const path = require('path');
 function resolve (dir) {
     return path.join(__dirname, dir)
@@ -24,6 +25,10 @@ module.exports = {
       .set('@components', resolve('packages/components'))
       .set('@utils', resolve('packages/utils'))
       .set('@mixins', resolve('packages/mixins'))
+    config.plugin('optimize')
+      .use(webpack.optimize.LimitChunkCountPlugin, [{
+        maxChunks: 1
+      }])
   },
 
   devServer: {


### PR DESCRIPTION
新增了一个单个组件宽度设置，然后 `yarn lib` 打包时出现 2 个 umd 文件： `lib/index.umd.min.js` 和 `lib/index.umd.min.js`。
之后在项目中使用，在导入/生成 JSON 时会出现报错问题，将 Chunk 包限制为 1 个解决了这个问题。